### PR TITLE
Add third party license txt and a draft of Tasty cli studio

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,6 +31,12 @@
       "commands": [
         "wyam"
       ]
+    },
+    "thirdlicense": {
+      "version": "1.1.0",
+      "commands": [
+        "thirdlicense"
+      ]
     }
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Fetch all history for all tags and branches
       run: |
         git fetch --prune --unshallow
+        git submodule init
+        git submodule update
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 node_modules
+src/**/THIRD-PARTY-NOTICES.TXT
 
 # User-specific files
 *.rsuser

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/gui.cs"]
+	path = ext/gui.cs
+	url = https://github.com/migueldeicaza/gui.cs.git

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,10 @@
     <TargetFrameworks>$(NetStandardVersion)</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(FullFrameworkVersion)'">
+    <DefineConstants>$(DefineConstants);FULL_FRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)img\icon-64x64.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>

--- a/Xenial.Tasty.sln
+++ b/Xenial.Tasty.sln
@@ -56,23 +56,32 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyFirstTastyTests", "demos\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestGroupTests", "demos\TestGroupTests\TestGroupTests.csproj", "{849D72DB-8A7F-4504-A447-742BD40825F2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeSetupTests", "demos\NativeSetupTests\NativeSetupTests.csproj", "{CFBA56A1-2B77-4E33-AFBA-54DD9B1BA98B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeSetupTests", "demos\NativeSetupTests\NativeSetupTests.csproj", "{CFBA56A1-2B77-4E33-AFBA-54DD9B1BA98B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupTests", "demos\SetupTests\SetupTests.csproj", "{316CF6A7-A0BB-479D-A656-71F5EE22C7C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SetupTests", "demos\SetupTests\SetupTests.csproj", "{316CF6A7-A0BB-479D-A656-71F5EE22C7C8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupScopeTests", "demos\SetupScopeTests\SetupScopeTests.csproj", "{C638F06C-C489-42B4-8F8C-54B864F11F0C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SetupScopeTests", "demos\SetupScopeTests\SetupScopeTests.csproj", "{C638F06C-C489-42B4-8F8C-54B864F11F0C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FocusedTests", "demos\FocusedTests\FocusedTests.csproj", "{11728621-44B4-4FAA-985B-147F12CA5E48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FocusedTests", "demos\FocusedTests\FocusedTests.csproj", "{11728621-44B4-4FAA-985B-147F12CA5E48}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReturnCodes", "demos\ReturnCodes\ReturnCodes.csproj", "{6C847135-CA1C-4973-B791-4F51DA4B88BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReturnCodes", "demos\ReturnCodes\ReturnCodes.csproj", "{6C847135-CA1C-4973-B791-4F51DA4B88BB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataDrivenTests", "demos\DataDrivenTests\DataDrivenTests.csproj", "{38A00997-F6C6-4D98-B842-3FC19E999B13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataDrivenTests", "demos\DataDrivenTests\DataDrivenTests.csproj", "{38A00997-F6C6-4D98-B842-3FC19E999B13}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrganizingTests", "demos\OrganizingTests\OrganizingTests.csproj", "{E480FD02-8D84-4950-BBCC-5E20893B4037}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrganizingTests", "demos\OrganizingTests\OrganizingTests.csproj", "{E480FD02-8D84-4950-BBCC-5E20893B4037}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrganizingWithReflectionTests", "demos\OrganizingWithReflectionTests\OrganizingWithReflectionTests.csproj", "{AC77FD21-B4F1-4BCC-8524-217CC96D2C7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrganizingWithReflectionTests", "demos\OrganizingWithReflectionTests\OrganizingWithReflectionTests.csproj", "{AC77FD21-B4F1-4BCC-8524-217CC96D2C7B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xenial.Tasty.Cli", "src\Xenial.Tasty.Cli\Xenial.Tasty.Cli.csproj", "{F9A31E0C-1C93-4464-969B-3052E0686EAA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xenial.Tasty.Cli", "src\Xenial.Tasty.Cli\Xenial.Tasty.Cli.csproj", "{F9A31E0C-1C93-4464-969B-3052E0686EAA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ext", "ext", "{55AA44C1-3863-4DA9-A6C5-F20C126E7428}"
+	ProjectSection(SolutionItems) = preProject
+		ext\Directory.Build.props = ext\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "gui.cs", "gui.cs", "{B7A10ABF-1935-438D-B7C9-5E298FC727B8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terminal.Gui", "ext\gui.cs\Terminal.Gui\Terminal.Gui.csproj", "{C9812129-852C-4A84-95CC-73EF4C2A7A3B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -360,6 +369,18 @@ Global
 		{F9A31E0C-1C93-4464-969B-3052E0686EAA}.Release|x64.Build.0 = Release|Any CPU
 		{F9A31E0C-1C93-4464-969B-3052E0686EAA}.Release|x86.ActiveCfg = Release|Any CPU
 		{F9A31E0C-1C93-4464-969B-3052E0686EAA}.Release|x86.Build.0 = Release|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Debug|x64.Build.0 = Debug|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Debug|x86.Build.0 = Debug|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Release|x64.ActiveCfg = Release|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Release|x64.Build.0 = Release|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Release|x86.ActiveCfg = Release|Any CPU
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -389,6 +410,8 @@ Global
 		{E480FD02-8D84-4950-BBCC-5E20893B4037} = {9CAF2D6C-1E62-4F98-844F-07EFAAEEC5F4}
 		{AC77FD21-B4F1-4BCC-8524-217CC96D2C7B} = {9CAF2D6C-1E62-4F98-844F-07EFAAEEC5F4}
 		{F9A31E0C-1C93-4464-969B-3052E0686EAA} = {CEC91D22-0825-4CCF-BF0E-13ED88FB6D6B}
+		{B7A10ABF-1935-438D-B7C9-5E298FC727B8} = {55AA44C1-3863-4DA9-A6C5-F20C126E7428}
+		{C9812129-852C-4A84-95CC-73EF4C2A7A3B} = {B7A10ABF-1935-438D-B7C9-5E298FC727B8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4D25470F-FCE8-4F98-A5B0-BE1C68CFEE7D}

--- a/build/Tasty.Build/Program.cs
+++ b/build/Tasty.Build/Program.cs
@@ -30,7 +30,7 @@ namespace Tasty.Build
             );
 
             Target("lint", DependsOn("ensure-tools"),
-                () => RunAsync("dotnet", $"format --exclude ext --check --verbosity detailed")
+                () => RunAsync("dotnet", $"format --exclude ext --check --verbosity diagnostic")
             );
 
             Target("format", DependsOn("ensure-tools"),

--- a/build/Tasty.Build/Program.cs
+++ b/build/Tasty.Build/Program.cs
@@ -61,15 +61,25 @@ namespace Tasty.Build
                 await Task.WhenAll(tests);
             });
 
-            Target("pack.nuget", DependsOn("test"),
+            Target("lic.nuget", DependsOn("test"),
+                () => RunAsync("dotnet", "thirdlicense --project src/Xenial.Tasty/Xenial.Tasty.csproj --output src/Xenial.Tasty/THIRD-PARTY-NOTICES.TXT")
+            );
+
+            Target("lic.tools", DependsOn("test"),
+                () => RunAsync("dotnet", "thirdlicense --project src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj --output src/Xenial.Tasty.Cli/THIRD-PARTY-NOTICES.TXT")
+            );
+
+            Target("pack.nuget", DependsOn("lic.nuget"),
                 () => RunAsync("dotnet", $"pack src/Xenial.Tasty/Xenial.Tasty.csproj --no-restore --no-build -c {Configuration} {logOptions("pack.nuget")} {properties()}")
             );
 
-            Target("pack.tools", DependsOn("test"),
+            Target("lic", DependsOn("lic.nuget", "lic.tools"));
+
+            Target("pack.tools", DependsOn("lic.tools"),
                 () => RunAsync("dotnet", $"pack src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj --no-restore --no-build -c {Configuration} {logOptions("pack.tools")} {properties()}")
             );
 
-            Target("pack", DependsOn("pack.nuget", "pack.tools"));
+            Target("pack", DependsOn("lic", "pack.nuget", "pack.tools"));
 
             Target("docs",
                 () => RunAsync("dotnet", "wyam docs -o ../artifacts/docs")

--- a/build/Tasty.Build/Program.cs
+++ b/build/Tasty.Build/Program.cs
@@ -30,11 +30,11 @@ namespace Tasty.Build
             );
 
             Target("lint", DependsOn("ensure-tools"),
-                () => RunAsync("dotnet", $"format --check --verbosity detailed")
+                () => RunAsync("dotnet", $"format --exclude ext --check --verbosity detailed")
             );
 
             Target("format", DependsOn("ensure-tools"),
-                () => RunAsync("dotnet", $"format")
+                () => RunAsync("dotnet", $"format --exclude ext")
             );
 
             Target("restore", DependsOn("lint"),

--- a/ext/Directory.Build.props
+++ b/ext/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  
+  <PropertyGroup>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Xenial.Tasty.Cli/Commands/InteractiveCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/InteractiveCommand.cs
@@ -1,0 +1,233 @@
+﻿using StreamJsonRpc;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xenial.Delicious.Protocols;
+
+using static SimpleExec.Command;
+using static Xenial.Delicious.Utils.PromiseHelper;
+
+namespace Xenial.Delicious.Cli.Commands
+{
+    public static class InteractiveCommand
+    {
+        public static async Task<int> Interactive(string project, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var path = Path.GetFullPath(project);
+                if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+                {
+                    var directoryName = new DirectoryInfo(path).Name;
+                    var csProjFileName = Path.Combine(path, $"{directoryName}.csproj");
+                    if (File.Exists(csProjFileName))
+                    {
+                        Console.WriteLine(csProjFileName);
+
+                        var connectionId = $"TASTY_{Guid.NewGuid()}";
+
+                        using var stream = new NamedPipeServerStream(connectionId, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+                        var connectionTask = stream.WaitForConnectionAsync(cancellationToken);
+                        var remoteTask = ReadAsync("dotnet",
+                            $"run -p \"{csProjFileName}\" -f netcoreapp3.1",
+                            noEcho: true,
+                            configureEnvironment: (env) =>
+                            {
+                                env.Add("TASTY_INTERACTIVE", "true");
+                                env.Add("TASTY_INTERACTIVE_CON_TYPE", "NamedPipes");
+                                env.Add("TASTY_INTERACTIVE_CON_ID", connectionId);
+                            }
+                        );
+
+                        Console.WriteLine("Connecting. NamedPipeServerStream...");
+                        await connectionTask;
+                        var server = new TastyServer();
+                        using var tastyServer = JsonRpc.Attach(stream, server);
+
+                        Console.WriteLine("Connected. NamedPipeServerStream...");
+                        try
+                        {
+                            Func<TastyServer, Task<IList<SerializableTastyCommand>>> waitForCommands = (TastyServer tastyServer) =>
+                                Promise<IList<SerializableTastyCommand>>((resolve, reject) =>
+                                {
+                                    var cts = new CancellationTokenSource();
+                                    cts.CancelAfter(10000);
+                                    cts.Token.Register(() => reject(cts.Token));
+
+                                    tastyServer.CommandsRegistered = (c) =>
+                                    {
+                                        cts.Dispose();
+                                        tastyServer.CommandsRegistered = null;
+                                        resolve(c);
+                                    };
+                                });
+
+                            var uiTask = Task.Run(async () =>
+                            {
+                                var commands = await waitForCommands(server);
+                                await Task.Run(async () => await WaitForInput(commands, server), cancellationToken);
+                                Console.WriteLine("UI-Task ended");
+                            }, cancellationToken);
+
+                            await Task.WhenAll(remoteTask, uiTask);
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            return 0;
+                        }
+                        catch (SimpleExec.NonZeroExitCodeException e)
+                        {
+                            return e.ExitCode;
+                        }
+                    }
+                }
+                return 0;
+            }
+            catch (TaskCanceledException)
+            {
+                return 1;
+            }
+        }
+
+        static Task WaitForInput(IList<SerializableTastyCommand> commands, TastyServer tastyServer)
+            => Promise(async (resolve) =>
+            {
+                Func<Task> cancelKeyPress = () => Promise((resolve, reject) =>
+                {
+                    Console.CancelKeyPress += (_, e) =>
+                    {
+                        if (e.Cancel)
+                        {
+                            Console.WriteLine("Cancelling execution...");
+                            reject();
+                        }
+                    };
+                });
+
+                Func<Task> endTestPipelineSignaled = () => Promise((resolve) =>
+                {
+                    tastyServer.EndTestPipelineSignaled = () =>
+                    {
+                        Console.WriteLine("Pipeline ended.");
+                        resolve();
+                    };
+                });
+
+                Func<Task> testPipelineCompletedSignaled = () => Promise((resolve) =>
+                {
+                    tastyServer.TestPipelineCompletedSignaled = () =>
+                    {
+                        Console.WriteLine("Pipeline completed.");
+                        resolve();
+                    };
+                });
+
+                Func<Task<ConsoleKeyInfo>> readConsoleKey = () => Promise<ConsoleKeyInfo>(resolve =>
+                {
+                    _ = Task.Run(() =>
+                    {
+                        var info = Console.ReadKey(true);
+                        resolve(info);
+                    });
+                });
+
+                Action writeCommands = () =>
+                {
+                    Console.WriteLine("Interactive Mode");
+                    Console.WriteLine("================");
+
+                    foreach (var c in commands)
+                    {
+                        Console.WriteLine($"{c.Name} - {c.Description}" + (c.IsDefault ? " (default)" : string.Empty));
+                    }
+
+                    Console.WriteLine("c - Cancel");
+                    Console.WriteLine("================");
+                };
+
+                Func<ConsoleKeyInfo, SerializableTastyCommand?> findCommand = (info) =>
+                {
+                    var key = info.Key.ToString().ToLower();
+
+                    var command = info.Key == ConsoleKey.Enter
+                        ? commands.FirstOrDefault(c => c.IsDefault)
+                        : commands.FirstOrDefault(c => c.Name.ToLowerInvariant() == key);
+
+                    return command;
+                };
+
+                Func<Task<Func<Task>>> readInput = async () =>
+                {
+                    var info = await readConsoleKey();
+                    var command = findCommand(info);
+                    if (command != null)
+                    {
+                        return async () =>
+                        {
+                            Console.WriteLine($"Executing {command.Name} - {command.Description}");
+
+                            await tastyServer.DoExecuteCommand(new ExecuteCommandEventArgs
+                            {
+                                CommandName = command.Name
+                            });
+                        };
+                    }
+                    if (info.Key == ConsoleKey.C)
+                    {
+                        return () => Promise(async (_, reject) =>
+                        {
+                            Console.WriteLine($"Requesting cancellation");
+
+                            await tastyServer.DoRequestCancellation();
+                            reject();
+                        });
+                    }
+
+                    return () => Task.CompletedTask;
+                };
+
+                Task waitForInput() => Promise(async (resolve, reject) =>
+                {
+                    writeCommands();
+                    var input = await readInput();
+
+                    var cancel = cancelKeyPress();
+                    var endTestPipeline = endTestPipelineSignaled();
+                    var completedTestPipleLine = testPipelineCompletedSignaled();
+
+                    try
+                    {
+                        var inputTask = input();
+                        if (inputTask.IsCanceled)
+                        {
+                            reject();
+                            return;
+                        }
+                        var result = await Task.WhenAny(cancel, endTestPipeline, completedTestPipleLine);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        reject();
+                        return;
+                    }
+                    if (endTestPipeline.IsCompletedSuccessfully)
+                    {
+                        resolve();
+                        return;
+                    }
+
+                    await waitForInput();
+                });
+                await waitForInput();
+                resolve();
+            });
+
+    }
+}

--- a/src/Xenial.Tasty.Cli/Commands/InteractiveCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/InteractiveCommand.cs
@@ -1,6 +1,4 @@
-﻿using StreamJsonRpc;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
@@ -8,9 +6,8 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
+using StreamJsonRpc;
 using Xenial.Delicious.Protocols;
-
 using static SimpleExec.Command;
 using static Xenial.Delicious.Utils.PromiseHelper;
 

--- a/src/Xenial.Tasty.Cli/Commands/InteractiveCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/InteractiveCommand.cs
@@ -151,11 +151,9 @@ namespace Xenial.Delicious.Cli.Commands
 
                 Func<ConsoleKeyInfo, SerializableTastyCommand?> findCommand = (info) =>
                 {
-                    var key = info.Key.ToString().ToLower();
-
                     var command = info.Key == ConsoleKey.Enter
                         ? commands.FirstOrDefault(c => c.IsDefault)
-                        : commands.FirstOrDefault(c => c.Name.ToLowerInvariant() == key);
+                        : commands.FirstOrDefault(c => string.Equals(c.Name, info.Key.ToString(), StringComparison.OrdinalIgnoreCase));
 
                     return command;
                 };

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -28,18 +28,22 @@ namespace Xenial.Delicious.Cli.Commands
             top.Add(win);
 
             // Creates a menubar, the item "New" has a help menu.
-            var menu = new MenuBar(new MenuBarItem[] {
-            new MenuBarItem ("_File", new MenuItem [] {
-                new MenuItem ("_New", "Creates new file", () => {}),
-                new MenuItem ("_Close", "", () => { }),
-                new MenuItem ("_Quit", "", () => { top.Running = false; })
-            }),
-            new MenuBarItem ("_Edit", new MenuItem [] {
-                new MenuItem ("_Copy", "", null),
-                new MenuItem ("C_ut", "", null),
-                new MenuItem ("_Paste", "", null)
-            })
-        });
+            var menu = new MenuBar(new[]
+            {
+                new MenuBarItem ("_File", new []
+                {
+                    new MenuItem ("_New", "Creates new file", () => {}),
+                    new MenuItem ("_Close", "", () => { }),
+                    new MenuItem ("_Quit", "", () => { top.Running = false; })
+                }),
+                new MenuBarItem ("_Edit", new []
+                {
+                    new MenuItem ("_Copy", "", null),
+                    new MenuItem ("C_ut", "", null),
+                    new MenuItem ("_Paste", "", null)
+                })
+            });
+
             top.Add(menu);
 
             var login = new Label("Login: ") { X = 3, Y = 2 };
@@ -63,16 +67,17 @@ namespace Xenial.Delicious.Cli.Commands
             };
 
             // Add some controls, 
-            win.Add(
+            win.Add
+            (
                 // The ones with my favorite layout system
                 login, password, loginText, passText,
-
-                    // The ones laid out like an australopithecus, with absolute positions:
-                    new CheckBox(3, 6, "Remember me"),
-                    new RadioGroup(3, 8, new[] { "_Personal", "_Company" }),
-                    new Button(3, 14, "Ok"),
-                    new Button(10, 14, "Cancel"),
-                    new Label(3, 18, "Press F9 or ESC plus 9 to activate the menubar"));
+                // The ones laid out like an australopithecus, with absolute positions:
+                new CheckBox(3, 6, "Remember me"),
+                new RadioGroup(3, 8, new[] { "_Personal", "_Company" }),
+                new Button(3, 14, "Ok"),
+                new Button(10, 14, "Cancel"),
+                new Label(3, 18, "Press F9 or ESC plus 9 to activate the menubar")
+            );
 
             Application.Run();
             return Task.FromResult(1);

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Terminal.Gui;
 
 namespace Xenial.Delicious.Cli.Commands
@@ -20,8 +21,20 @@ namespace Xenial.Delicious.Cli.Commands
             _top = Application.Top;
 
             // Creates a menubar, the item "New" has a help menu.
-            _menu = new MenuBar(new MenuBarItem[] {
-                new MenuBarItem ("_File", new MenuItem [] {
+            _menu = new MenuBar(new MenuBarItem[]
+            {
+                new MenuBarItem ("_File", new []
+                {
+                    new MenuItem ("_Open", "", () =>
+                    {
+                        var dialog = new OpenDialog()
+                        {
+                            AllowedFileTypes = new []{ "csproj", "exe", "dll"}
+                        };
+                        Application.Run (dialog);
+                        var filePaths = dialog.FilePaths;
+                    }
+                    ),
                     new MenuItem ("_Quit", "", () => Application.RequestStop() )
                 }),
                 new MenuBarItem ("_Color Scheme", CreateColorSchemeMenuItems()),

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -18,11 +18,11 @@ namespace Xenial.Delicious.Cli.Commands
         private static FrameView? _rightPane;
         private static Toplevel? _top;
         private static StatusBar? _statusBar;
-        public static Task<int> Studio(CancellationToken cancellationToken)
+        public static Task<int> Studio()
         {
             Application.Init();
             _top = Application.Top;
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             _leftPane = new FrameView("Commands")
             {

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 using Terminal.Gui;
 
@@ -10,15 +11,17 @@ namespace Xenial.Delicious.Cli.Commands
 {
     public static class StudioCommand
     {
+        private static MenuBar? _menu;
         private static FrameView? _leftPane;
         private static Toplevel? _top;
+        private static StatusBar? _statusBar;
         public static Task<int> Studio(CancellationToken cancellationToken)
         {
             Application.Init();
             _top = Application.Top;
 
             // Creates a menubar, the item "New" has a help menu.
-            var menu = new MenuBar(new MenuBarItem[] {
+            _menu = new MenuBar(new MenuBarItem[] {
                 new MenuBarItem ("_File", new MenuItem [] {
                     new MenuItem ("_Quit", "", () => Application.RequestStop() )
                 }),
@@ -35,7 +38,26 @@ namespace Xenial.Delicious.Cli.Commands
                 CanFocus = false,
             };
 
-            _top.Add(_leftPane, menu);
+            _statusBar = new StatusBar(new [] 
+            {
+                new StatusItem(Key.ControlQ, "~CTRL-Q~ Quit", () => 
+                {
+                    Application.RequestStop();
+                }),
+                new StatusItem(Key.ControlD, "~CTRL-D~ Debug", () =>
+                {
+                    if(!Debugger.IsAttached)
+                    {
+                        Debugger.Launch();
+                    }
+                }),
+                new StatusItem(Key.F9, "~F9~ Open Menu", () =>
+                {
+                    _menu.OpenMenu();
+                }),
+            });
+
+            _top.Add(_menu, _leftPane, _statusBar);
 
             SetColorScheme();
 

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -27,11 +27,13 @@ namespace Xenial.Delicious.Cli.Commands
                 {
                     new MenuItem ("_Open", "", () =>
                     {
-                        var dialog = new OpenDialog()
+                        var dialog = new OpenDialog
                         {
-                            AllowedFileTypes = new []{ "csproj", "exe", "dll"}
+                            AllowedFileTypes = new [] { "csproj", "exe", "dll"},
+                            CanChooseDirectories = false,
+                            AllowsMultipleSelection = false
                         };
-                        Application.Run (dialog);
+                        Application.Run(dialog);
                         var filePaths = dialog.FilePaths;
                     }
                     ),

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
-
 using Terminal.Gui;
 
 namespace Xenial.Delicious.Cli.Commands
@@ -38,9 +37,9 @@ namespace Xenial.Delicious.Cli.Commands
                 CanFocus = false,
             };
 
-            _statusBar = new StatusBar(new [] 
+            _statusBar = new StatusBar(new[]
             {
-                new StatusItem(Key.ControlQ, "~CTRL-Q~ Quit", () => 
+                new StatusItem(Key.ControlQ, "~CTRL-Q~ Quit", () =>
                 {
                     Application.RequestStop();
                 }),

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -136,7 +136,7 @@ namespace Xenial.Delicious.Cli.Commands
         static ColorScheme? _baseColorScheme;
         static MenuItem[] CreateColorSchemeMenuItems()
         {
-            List<MenuItem> menuItems = new List<MenuItem>();
+            List<MenuItem> menuItems = new List<MenuItem>(Colors.ColorSchemes.Count);
             foreach (var sc in Colors.ColorSchemes)
             {
                 var item = new MenuItem();

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -48,7 +48,7 @@ namespace Xenial.Delicious.Cli.Commands
 #pragma warning disable CS8601 // Possible null reference assignment.
             _leftPane!.ColorScheme = _baseColorScheme;
 #pragma warning restore CS8601 // Possible null reference assignment.
-                              // _rightPane.ColorScheme = _baseColorScheme;
+            // _rightPane.ColorScheme = _baseColorScheme;
             _top?.SetNeedsDisplay();
         }
 

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -60,7 +60,7 @@ namespace Xenial.Delicious.Cli.Commands
                         if(filePath != null)
                         {
                             var path = filePath.ToString();
-                            if(!string.IsNullOrEmpty(path) &&  System.IO.File.Exists(path))
+                            if(!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
                             {
                                 var commander = new TastyCommander();
 
@@ -92,8 +92,6 @@ namespace Xenial.Delicious.Cli.Commands
                 new MenuBarItem("_Color Scheme", CreateColorSchemeMenuItems()),
                 new MenuBarItem("_About...", "About Tasty.Cli", () => MessageBox.Query("About Tasty.Cli", aboutMessage.ToString(), "_Ok")),
             });
-
-
 
             _statusBar = new StatusBar(new[]
             {
@@ -130,8 +128,8 @@ namespace Xenial.Delicious.Cli.Commands
         {
 #pragma warning disable CS8601 // Possible null reference assignment.
             _leftPane!.ColorScheme = _baseColorScheme;
+            _rightPane!.ColorScheme = _baseColorScheme;
 #pragma warning restore CS8601 // Possible null reference assignment.
-            // _rightPane.ColorScheme = _baseColorScheme;
             _top?.SetNeedsDisplay();
         }
 

--- a/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
+++ b/src/Xenial.Tasty.Cli/Commands/StudioCommand.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Terminal.Gui;
+
+namespace Xenial.Delicious.Cli.Commands
+{
+    public static class StudioCommand
+    {
+        public static Task<int> Studio(CancellationToken cancellationToken)
+        {
+            Application.Init();
+            var top = Application.Top;
+
+            // Creates the top-level window to show
+            var win = new Window("MyApp")
+            {
+                X = 0,
+                Y = 1, // Leave one row for the toplevel menu
+
+                // By using Dim.Fill(), it will automatically resize without manual intervention
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
+            };
+            top.Add(win);
+
+            // Creates a menubar, the item "New" has a help menu.
+            var menu = new MenuBar(new MenuBarItem[] {
+            new MenuBarItem ("_File", new MenuItem [] {
+                new MenuItem ("_New", "Creates new file", () => {}),
+                new MenuItem ("_Close", "", () => { }),
+                new MenuItem ("_Quit", "", () => { top.Running = false; })
+            }),
+            new MenuBarItem ("_Edit", new MenuItem [] {
+                new MenuItem ("_Copy", "", null),
+                new MenuItem ("C_ut", "", null),
+                new MenuItem ("_Paste", "", null)
+            })
+        });
+            top.Add(menu);
+
+            var login = new Label("Login: ") { X = 3, Y = 2 };
+            var password = new Label("Password: ")
+            {
+                X = Pos.Left(login),
+                Y = Pos.Top(login) + 1
+            };
+            var loginText = new TextField("")
+            {
+                X = Pos.Right(password),
+                Y = Pos.Top(login),
+                Width = 40
+            };
+            var passText = new TextField("")
+            {
+                Secret = true,
+                X = Pos.Left(loginText),
+                Y = Pos.Top(password),
+                Width = Dim.Width(loginText)
+            };
+
+            // Add some controls, 
+            win.Add(
+                // The ones with my favorite layout system
+                login, password, loginText, passText,
+
+                    // The ones laid out like an australopithecus, with absolute positions:
+                    new CheckBox(3, 6, "Remember me"),
+                    new RadioGroup(3, 8, new[] { "_Personal", "_Company" }),
+                    new Button(3, 14, "Ok"),
+                    new Button(10, 14, "Cancel"),
+                    new Label(3, 18, "Press F9 or ESC plus 9 to activate the menubar"));
+
+            Application.Run();
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/src/Xenial.Tasty.Cli/GlobalSuppressions.cs
+++ b/src/Xenial.Tasty.Cli/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "VSTHRD101:Avoid unsupported async delegates", Justification = "<Pending>", Scope = "member", Target = "~M:Xenial.Delicious.Cli.Commands.StudioCommand.Studio(System.Threading.CancellationToken)~System.Threading.Tasks.Task{System.Int32}")]
+[assembly: SuppressMessage("Usage", "VSTHRD101:Avoid unsupported async delegates", Justification = "<Pending>", Scope = "member", Target = "~M:Xenial.Delicious.Cli.Commands.StudioCommand.Studio~System.Threading.Tasks.Task{System.Int32}")]

--- a/src/Xenial.Tasty.Cli/GlobalSuppressions.cs
+++ b/src/Xenial.Tasty.Cli/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "VSTHRD101:Avoid unsupported async delegates", Justification = "<Pending>", Scope = "member", Target = "~M:Xenial.Delicious.Cli.Commands.StudioCommand.Studio(System.Threading.CancellationToken)~System.Threading.Tasks.Task{System.Int32}")]

--- a/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
+++ b/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
@@ -21,10 +21,10 @@ namespace Xenial.Delicious.Cli.Internal
             {
                 var buildTask = BuildAsync(csProjFileName, cancellationToken);
 
-                await foreach (var (line, isRunning, exitCode) in buildTask)
+                await foreach (var (line, hasStopped, exitCode) in buildTask)
                 {
-                    progress.Report((line, isRunning, exitCode));
-                    if (!isRunning)
+                    progress.Report((line, hasStopped, exitCode));
+                    if (hasStopped)
                     {
                         return exitCode;
                     }
@@ -33,7 +33,7 @@ namespace Xenial.Delicious.Cli.Internal
             });
         }
 
-        public static async IAsyncEnumerable<(string, bool, int)> BuildAsync(string csProjFileName, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static async IAsyncEnumerable<(string line, bool hasStopped, int exitCode)> BuildAsync(string csProjFileName, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             using var proc = new Process
             {
@@ -58,7 +58,7 @@ namespace Xenial.Delicious.Cli.Internal
                     yield break;
                 }
                 var line = await reader.ReadLineAsync() ?? string.Empty;
-                yield return (line, true, 0);
+                yield return (line, false, 0);
             }
 
             var exitCode = await proc.WaitForExitAsync(cancellationToken);

--- a/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
+++ b/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Threading;
+
+using static SimpleExec.Command;
+
+namespace Xenial.Delicious.Cli.Internal
+{
+    internal class TastyCommander
+    {
+        public async Task<int> BuildProject(string csProjFileName, IProgress<(string line, bool isRunning, int exitCode)> progress, CancellationToken cancellationToken = default)
+        {
+            return await Task.Run(async () =>
+            {
+                var buildTask = BuildAsync(csProjFileName, cancellationToken);
+
+                await foreach (var (line, isRunning, exitCode) in buildTask)
+                {
+                    progress.Report((line, isRunning, exitCode));
+                    if (!isRunning)
+                    {
+                        return exitCode;
+                    }
+                }
+                return 0;
+            });
+        }
+
+        public static async IAsyncEnumerable<(string, bool, int)> BuildAsync(string csProjFileName, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            using var proc = new Process
+            {
+                StartInfo = new ProcessStartInfo("dotnet", $"build \"{csProjFileName}\" -f netcoreapp3.1")
+                {
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    WindowStyle = ProcessWindowStyle.Hidden
+                }
+            };
+
+            proc.Start();
+
+            using StreamReader reader = proc.StandardOutput;
+            while (!reader.EndOfStream)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    proc.Close();
+                    yield break;
+                }
+                var line = await reader.ReadLineAsync() ?? string.Empty;
+                yield return (line, true, 0);
+            }
+
+            var exitCode = await proc.WaitForExitAsync(cancellationToken);
+            yield return (string.Empty, true, exitCode);
+        }
+    }
+}

--- a/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
+++ b/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
@@ -46,7 +46,7 @@ namespace Xenial.Delicious.Cli.Internal
 
                     //On windows dotnet core seams to set the codepage to 850
                     //see: https://github.com/dotnet/runtime/issues/17849#issuecomment-353612399
-                    StandardOutputEncoding = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+                    StandardOutputEncoding = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                         ? Encoding.GetEncoding(850) //DOS-Latin-1
                         : Encoding.Default,
                 }

--- a/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
+++ b/src/Xenial.Tasty.Cli/Internal/TastyCommander.cs
@@ -2,14 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Threading;
-
-using static SimpleExec.Command;
 
 namespace Xenial.Delicious.Cli.Internal
 {
@@ -43,7 +43,12 @@ namespace Xenial.Delicious.Cli.Internal
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
-                    WindowStyle = ProcessWindowStyle.Hidden
+
+                    //On windows dotnet core seams to set the codepage to 850
+                    //see: https://github.com/dotnet/runtime/issues/17849#issuecomment-353612399
+                    StandardOutputEncoding = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+                        ? Encoding.GetEncoding(850) //DOS-Latin-1
+                        : Encoding.Default,
                 }
             };
 

--- a/src/Xenial.Tasty.Cli/Program.cs
+++ b/src/Xenial.Tasty.Cli/Program.cs
@@ -2,6 +2,8 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +15,16 @@ namespace Xenial.Delicious.Cli
     {
         static async Task<int> Main(string[] args)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                //Register additional code pages for windows
+                //cause we deal directly with process streams
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            }
+
+            Console.OutputEncoding = Encoding.UTF8;
+            Console.InputEncoding = Encoding.UTF8;
+
             var rootCommand = new RootCommand();
 
             var interactiveCommand = new Command("interactive")

--- a/src/Xenial.Tasty.Cli/Program.cs
+++ b/src/Xenial.Tasty.Cli/Program.cs
@@ -1,23 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
-using System.IO.Pipes;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.Threading;
-
-using StreamJsonRpc;
-
-using Terminal.Gui;
-
-using Xenial.Delicious.Protocols;
-
-using static SimpleExec.Command;
-using static Xenial.Delicious.Utils.PromiseHelper;
+using Xenial.Delicious.Cli.Commands;
 
 namespace Xenial.Delicious.Cli
 {
@@ -29,7 +17,7 @@ namespace Xenial.Delicious.Cli
 
             var interactiveCommand = new Command("interactive")
             {
-                Handler = CommandHandler.Create<string, CancellationToken>(Interactive)
+                Handler = CommandHandler.Create<string, CancellationToken>(InteractiveCommand.Interactive)
             };
             interactiveCommand.AddAlias("i");
             var arg = new Option<string>("--project");
@@ -39,291 +27,12 @@ namespace Xenial.Delicious.Cli
 
             var studioCommand = new Command("studio")
             {
-                Handler = CommandHandler.Create<CancellationToken>(Studio)
+                Handler = CommandHandler.Create<CancellationToken>(StudioCommand.Studio)
             };
             studioCommand.AddAlias("s");
             rootCommand.Add(studioCommand);
 
             return await rootCommand.InvokeAsync(args);
-        }
-
-        static async Task<int> Interactive(string project, CancellationToken cancellationToken)
-        {
-            try
-            {
-                var path = Path.GetFullPath(project);
-                if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
-                {
-                    var directoryName = new DirectoryInfo(path).Name;
-                    var csProjFileName = Path.Combine(path, $"{directoryName}.csproj");
-                    if (File.Exists(csProjFileName))
-                    {
-                        Console.WriteLine(csProjFileName);
-
-                        var connectionId = $"TASTY_{Guid.NewGuid()}";
-
-                        using var stream = new NamedPipeServerStream(connectionId, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-                        var connectionTask = stream.WaitForConnectionAsync(cancellationToken);
-                        var remoteTask = ReadAsync("dotnet",
-                            $"run -p \"{csProjFileName}\" -f netcoreapp3.1",
-                            noEcho: true,
-                            configureEnvironment: (env) =>
-                            {
-                                env.Add("TASTY_INTERACTIVE", "true");
-                                env.Add("TASTY_INTERACTIVE_CON_TYPE", "NamedPipes");
-                                env.Add("TASTY_INTERACTIVE_CON_ID", connectionId);
-                            }
-                        );
-
-                        Console.WriteLine("Connecting. NamedPipeServerStream...");
-                        await connectionTask;
-                        var server = new TastyServer();
-                        using var tastyServer = JsonRpc.Attach(stream, server);
-
-                        Console.WriteLine("Connected. NamedPipeServerStream...");
-                        try
-                        {
-                            Func<TastyServer, Task<IList<SerializableTastyCommand>>> waitForCommands = (TastyServer tastyServer) =>
-                                Promise<IList<SerializableTastyCommand>>((resolve, reject) =>
-                                {
-                                    var cts = new CancellationTokenSource();
-                                    cts.CancelAfter(10000);
-                                    cts.Token.Register(() => reject(cts.Token));
-
-                                    tastyServer.CommandsRegistered = (c) =>
-                                    {
-                                        cts.Dispose();
-                                        tastyServer.CommandsRegistered = null;
-                                        resolve(c);
-                                    };
-                                });
-
-                            var uiTask = Task.Run(async () =>
-                            {
-                                var commands = await waitForCommands(server);
-                                await Task.Run(async () => await WaitForInput(commands, server), cancellationToken);
-                                Console.WriteLine("UI-Task ended");
-                            }, cancellationToken);
-
-                            await Task.WhenAll(remoteTask, uiTask);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            return 0;
-                        }
-                        catch (SimpleExec.NonZeroExitCodeException e)
-                        {
-                            return e.ExitCode;
-                        }
-                    }
-                }
-                return 0;
-            }
-            catch (TaskCanceledException)
-            {
-                return 1;
-            }
-        }
-
-        static Task WaitForInput(IList<SerializableTastyCommand> commands, TastyServer tastyServer)
-            => Promise(async (resolve) =>
-            {
-                Func<Task> cancelKeyPress = () => Promise((resolve, reject) =>
-                {
-                    Console.CancelKeyPress += (_, e) =>
-                    {
-                        if (e.Cancel)
-                        {
-                            Console.WriteLine("Cancelling execution...");
-                            reject();
-                        }
-                    };
-                });
-
-                Func<Task> endTestPipelineSignaled = () => Promise((resolve) =>
-                {
-                    tastyServer.EndTestPipelineSignaled = () =>
-                    {
-                        Console.WriteLine("Pipeline ended.");
-                        resolve();
-                    };
-                });
-
-                Func<Task> testPipelineCompletedSignaled = () => Promise((resolve) =>
-                {
-                    tastyServer.TestPipelineCompletedSignaled = () =>
-                    {
-                        Console.WriteLine("Pipeline completed.");
-                        resolve();
-                    };
-                });
-
-                Func<Task<ConsoleKeyInfo>> readConsoleKey = () => Promise<ConsoleKeyInfo>(resolve =>
-                {
-                    _ = Task.Run(() =>
-                    {
-                        var info = Console.ReadKey(true);
-                        resolve(info);
-                    });
-                });
-
-                Action writeCommands = () =>
-                {
-                    Console.WriteLine("Interactive Mode");
-                    Console.WriteLine("================");
-
-                    foreach (var c in commands)
-                    {
-                        Console.WriteLine($"{c.Name} - {c.Description}" + (c.IsDefault ? " (default)" : string.Empty));
-                    }
-
-                    Console.WriteLine("c - Cancel");
-                    Console.WriteLine("================");
-                };
-
-                Func<ConsoleKeyInfo, SerializableTastyCommand?> findCommand = (info) =>
-                {
-                    var key = info.Key.ToString().ToLower();
-
-                    var command = info.Key == ConsoleKey.Enter
-                        ? commands.FirstOrDefault(c => c.IsDefault)
-                        : commands.FirstOrDefault(c => c.Name.ToLowerInvariant() == key);
-
-                    return command;
-                };
-
-                Func<Task<Func<Task>>> readInput = async () =>
-                {
-                    var info = await readConsoleKey();
-                    var command = findCommand(info);
-                    if (command != null)
-                    {
-                        return async () =>
-                        {
-                            Console.WriteLine($"Executing {command.Name} - {command.Description}");
-
-                            await tastyServer.DoExecuteCommand(new ExecuteCommandEventArgs
-                            {
-                                CommandName = command.Name
-                            });
-                        };
-                    }
-                    if (info.Key == ConsoleKey.C)
-                    {
-                        return () => Promise(async (_, reject) =>
-                        {
-                            Console.WriteLine($"Requesting cancellation");
-
-                            await tastyServer.DoRequestCancellation();
-                            reject();
-                        });
-                    }
-
-                    return () => Task.CompletedTask;
-                };
-
-                Task waitForInput() => Promise(async (resolve, reject) =>
-                {
-                    writeCommands();
-                    var input = await readInput();
-
-                    var cancel = cancelKeyPress();
-                    var endTestPipeline = endTestPipelineSignaled();
-                    var completedTestPipleLine = testPipelineCompletedSignaled();
-
-                    try
-                    {
-                        var inputTask = input();
-                        if (inputTask.IsCanceled)
-                        {
-                            reject();
-                            return;
-                        }
-                        var result = await Task.WhenAny(cancel, endTestPipeline, completedTestPipleLine);
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        reject();
-                        return;
-                    }
-                    if (endTestPipeline.IsCompletedSuccessfully)
-                    {
-                        resolve();
-                        return;
-                    }
-
-                    await waitForInput();
-                });
-                await waitForInput();
-                resolve();
-            });
-
-        static Task<int> Studio(CancellationToken cancellationToken)
-        {
-            Application.Init();
-            var top = Application.Top;
-
-            // Creates the top-level window to show
-            var win = new Window("MyApp")
-            {
-                X = 0,
-                Y = 1, // Leave one row for the toplevel menu
-
-                // By using Dim.Fill(), it will automatically resize without manual intervention
-                Width = Dim.Fill(),
-                Height = Dim.Fill()
-            };
-            top.Add(win);
-
-            // Creates a menubar, the item "New" has a help menu.
-            var menu = new MenuBar(new MenuBarItem[] {
-            new MenuBarItem ("_File", new MenuItem [] {
-                new MenuItem ("_New", "Creates new file", () => {}),
-                new MenuItem ("_Close", "", () => { }),
-                new MenuItem ("_Quit", "", () => { top.Running = false; })
-            }),
-            new MenuBarItem ("_Edit", new MenuItem [] {
-                new MenuItem ("_Copy", "", null),
-                new MenuItem ("C_ut", "", null),
-                new MenuItem ("_Paste", "", null)
-            })
-        });
-            top.Add(menu);
-
-            var login = new Label("Login: ") { X = 3, Y = 2 };
-            var password = new Label("Password: ")
-            {
-                X = Pos.Left(login),
-                Y = Pos.Top(login) + 1
-            };
-            var loginText = new TextField("")
-            {
-                X = Pos.Right(password),
-                Y = Pos.Top(login),
-                Width = 40
-            };
-            var passText = new TextField("")
-            {
-                Secret = true,
-                X = Pos.Left(loginText),
-                Y = Pos.Top(password),
-                Width = Dim.Width(loginText)
-            };
-
-            // Add some controls, 
-            win.Add(
-                // The ones with my favorite layout system
-                login, password, loginText, passText,
-
-                    // The ones laid out like an australopithecus, with absolute positions:
-                    new CheckBox(3, 6, "Remember me"),
-                    new RadioGroup(3, 8, new[] { "_Personal", "_Company" }),
-                    new Button(3, 14, "Ok"),
-                    new Button(10, 14, "Cancel"),
-                    new Label(3, 18, "Press F9 or ESC plus 9 to activate the menubar"));
-
-            Application.Run();
-            return Task.FromResult(1);
         }
     }
 }

--- a/src/Xenial.Tasty.Cli/Program.cs
+++ b/src/Xenial.Tasty.Cli/Program.cs
@@ -15,15 +15,7 @@ namespace Xenial.Delicious.Cli
     {
         static async Task<int> Main(string[] args)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                //Register additional code pages for windows
-                //cause we deal directly with process streams
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            }
-
-            Console.OutputEncoding = Encoding.UTF8;
-            Console.InputEncoding = Encoding.UTF8;
+            SetupConsoleEncoding();
 
             var rootCommand = new RootCommand();
 
@@ -45,6 +37,19 @@ namespace Xenial.Delicious.Cli
             rootCommand.Add(studioCommand);
 
             return await rootCommand.InvokeAsync(args);
+        }
+
+        private static void SetupConsoleEncoding()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                //Register additional code pages for windows
+                //cause we deal directly with process streams
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            }
+
+            Console.OutputEncoding = Encoding.UTF8;
+            Console.InputEncoding = Encoding.UTF8;
         }
     }
 }

--- a/src/Xenial.Tasty.Cli/Program.cs
+++ b/src/Xenial.Tasty.Cli/Program.cs
@@ -39,7 +39,7 @@ namespace Xenial.Delicious.Cli
 
             var studioCommand = new Command("studio")
             {
-                Handler = CommandHandler.Create<CancellationToken>(StudioCommand.Studio)
+                Handler = CommandHandler.Create(StudioCommand.Studio)
             };
             studioCommand.AddAlias("s");
             rootCommand.Add(studioCommand);

--- a/src/Xenial.Tasty.Cli/Program.cs
+++ b/src/Xenial.Tasty.Cli/Program.cs
@@ -12,6 +12,8 @@ using Microsoft.VisualStudio.Threading;
 
 using StreamJsonRpc;
 
+using Terminal.Gui;
+
 using Xenial.Delicious.Protocols;
 
 using static SimpleExec.Command;
@@ -34,6 +36,13 @@ namespace Xenial.Delicious.Cli
             arg.AddAlias("-p");
             interactiveCommand.Add(arg);
             rootCommand.Add(interactiveCommand);
+
+            var studioCommand = new Command("studio")
+            {
+                Handler = CommandHandler.Create<CancellationToken>(Studio)
+            };
+            studioCommand.AddAlias("s");
+            rootCommand.Add(studioCommand);
 
             return await rootCommand.InvokeAsync(args);
         }
@@ -248,5 +257,73 @@ namespace Xenial.Delicious.Cli
                 await waitForInput();
                 resolve();
             });
+
+        static Task<int> Studio(CancellationToken cancellationToken)
+        {
+            Application.Init();
+            var top = Application.Top;
+
+            // Creates the top-level window to show
+            var win = new Window("MyApp")
+            {
+                X = 0,
+                Y = 1, // Leave one row for the toplevel menu
+
+                // By using Dim.Fill(), it will automatically resize without manual intervention
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
+            };
+            top.Add(win);
+
+            // Creates a menubar, the item "New" has a help menu.
+            var menu = new MenuBar(new MenuBarItem[] {
+            new MenuBarItem ("_File", new MenuItem [] {
+                new MenuItem ("_New", "Creates new file", () => {}),
+                new MenuItem ("_Close", "", () => { }),
+                new MenuItem ("_Quit", "", () => { top.Running = false; })
+            }),
+            new MenuBarItem ("_Edit", new MenuItem [] {
+                new MenuItem ("_Copy", "", null),
+                new MenuItem ("C_ut", "", null),
+                new MenuItem ("_Paste", "", null)
+            })
+        });
+            top.Add(menu);
+
+            var login = new Label("Login: ") { X = 3, Y = 2 };
+            var password = new Label("Password: ")
+            {
+                X = Pos.Left(login),
+                Y = Pos.Top(login) + 1
+            };
+            var loginText = new TextField("")
+            {
+                X = Pos.Right(password),
+                Y = Pos.Top(login),
+                Width = 40
+            };
+            var passText = new TextField("")
+            {
+                Secret = true,
+                X = Pos.Left(loginText),
+                Y = Pos.Top(password),
+                Width = Dim.Width(loginText)
+            };
+
+            // Add some controls, 
+            win.Add(
+                // The ones with my favorite layout system
+                login, password, loginText, passText,
+
+                    // The ones laid out like an australopithecus, with absolute positions:
+                    new CheckBox(3, 6, "Remember me"),
+                    new RadioGroup(3, 8, new[] { "_Personal", "_Company" }),
+                    new Button(3, 14, "Ok"),
+                    new Button(10, 14, "Cancel"),
+                    new Label(3, 18, "Press F9 or ESC plus 9 to activate the menubar"));
+
+            Application.Run();
+            return Task.FromResult(1);
+        }
     }
 }

--- a/src/Xenial.Tasty.Cli/Properties/launchSettings.json
+++ b/src/Xenial.Tasty.Cli/Properties/launchSettings.json
@@ -1,8 +1,12 @@
 {
   "profiles": {
-    "Xenial.Tasty.Cli": {
+    "Interactive": {
       "commandName": "Project",
       "commandLineArgs": "i -p ../../../../../test/Xenial.Tasty.Tests"
+    },
+    "Cli Studio": {
+      "commandName": "Project",
+      "commandLineArgs": "s"
     }
   }
 }

--- a/src/Xenial.Tasty.Cli/Properties/launchSettings.json
+++ b/src/Xenial.Tasty.Cli/Properties/launchSettings.json
@@ -6,7 +6,8 @@
     },
     "Cli Studio": {
       "commandName": "Project",
-      "commandLineArgs": "s"
+      "commandLineArgs": "s",
+      "workingDirectory": "../../test/Xenial.Tasty.Tests"
     }
   }
 }

--- a/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
+++ b/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
@@ -8,16 +8,17 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>tasty</ToolCommandName>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <PublishSingleFile>true6</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
     <PackageReference Include="SimpleExec" Version="6.2.0" />
     <PackageReference Include="Terminal" Version="0.2.0" />
-    <PackageReference Include="Terminal.Gui" Version="0.81.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\ext\gui.cs\Terminal.Gui\Terminal.Gui.csproj" />
     <ProjectReference Include="..\Xenial.Tasty\Xenial.Tasty.csproj" />
   </ItemGroup>
 

--- a/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
+++ b/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
@@ -8,7 +8,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>tasty</ToolCommandName>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
+++ b/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>tasty</ToolCommandName>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <PublishSingleFile>true6</PublishSingleFile>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
+++ b/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
     <PackageReference Include="SimpleExec" Version="6.2.0" />
+    <PackageReference Include="Terminal" Version="0.2.0" />
+    <PackageReference Include="Terminal.Gui" Version="0.81.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
+++ b/src/Xenial.Tasty.Cli/Xenial.Tasty.Cli.csproj
@@ -20,7 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Commands\" />
+    <None Include="THIRD-PARTY-NOTICES.TXT">
+      <Pack>true</Pack>
+      <PackagePath></PackagePath>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Xenial.Tasty/FeatureDetection/FeatureDetector.cs
+++ b/src/Xenial.Tasty/FeatureDetection/FeatureDetector.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Xenial.Delicious.FeatureDetection.Win;
+
+namespace Xenial.Delicious.FeatureDetection
+{
+    internal static class FeatureDetector
+    {
+        internal static readonly string[] CmdProcessNames = new[]
+        {
+            "cmd",
+            "VsDebugConsole",
+            "powershell"
+        };
+
+        internal static bool IsWindows()
+            => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static bool IsCmd()
+        {
+            var proc = Process.GetCurrentProcess();
+
+            bool IsCmdProc(Process process)
+            {
+                if (process != null)
+                {
+                    if (CmdProcessNames.Any(name => string.Equals(name, process.ProcessName, StringComparison.CurrentCultureIgnoreCase)))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            while(proc != null)
+            {
+                if(IsCmdProc(proc))
+                {
+                    return true;
+                }
+                proc = proc.Parent();
+            }
+            return false;
+        }
+
+        internal static bool IsWindowsTerminal()
+        {
+            var env = Environment.GetEnvironmentVariable("WT_SESSION");
+            if (!string.IsNullOrEmpty(env) && Guid.TryParse(env, out _))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        internal static bool SupportsRichContent()
+        {
+            if(!IsWindows())
+            {
+                return true;
+            }
+
+            if(IsWindowsTerminal())
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Xenial.Tasty/FeatureDetection/FeatureDetector.cs
+++ b/src/Xenial.Tasty/FeatureDetection/FeatureDetector.cs
@@ -36,9 +36,9 @@ namespace Xenial.Delicious.FeatureDetection
                 }
                 return false;
             }
-            while(proc != null)
+            while (proc != null)
             {
-                if(IsCmdProc(proc))
+                if (IsCmdProc(proc))
                 {
                     return true;
                 }
@@ -59,12 +59,12 @@ namespace Xenial.Delicious.FeatureDetection
 
         internal static bool SupportsRichContent()
         {
-            if(!IsWindows())
+            if (!IsWindows())
             {
                 return true;
             }
 
-            if(IsWindowsTerminal())
+            if (IsWindowsTerminal())
             {
                 return true;
             }

--- a/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.Toolhelp32.cs
+++ b/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.Toolhelp32.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Xenial.Delicious.FeatureDetection.Win
+{
+    internal static class Toolhelp32
+    {
+        internal const uint Inherit = 0x80000000;
+        internal const uint SnapModule32 = 0x00000010;
+        internal const uint SnapAll = SnapHeapList | SnapModule | SnapProcess | SnapThread;
+        internal const uint SnapHeapList = 0x00000001;
+        internal const uint SnapProcess = 0x00000002;
+        internal const uint SnapThread = 0x00000004;
+        internal const uint SnapModule = 0x00000008;
+
+        [DllImport("kernel32.dll")]
+        static extern bool CloseHandle(IntPtr handle);
+        [DllImport("kernel32.dll")]
+        static extern IntPtr CreateToolhelp32Snapshot(uint flags, int processId);
+
+        internal static IEnumerable<T> TakeSnapshot<T>(uint flags, int id) where T : IEntry, new()
+        {
+            using (var snap = new Snapshot(flags, id))
+                for (IEntry entry = new T { }; entry.TryMoveNext(snap, out entry);)
+                    yield return (T)entry;
+        }
+
+        internal interface IEntry
+        {
+            internal bool TryMoveNext(Snapshot snap, out IEntry entry);
+        }
+
+        internal struct Snapshot : IDisposable
+        {
+            void IDisposable.Dispose()
+            {
+                CloseHandle(m_handle);
+            }
+            internal Snapshot(uint flags, int processId)
+            {
+                m_handle = CreateToolhelp32Snapshot(flags, processId);
+            }
+            IntPtr m_handle;
+        }
+    }
+}

--- a/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.WinProcessEntry.cs
+++ b/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.WinProcessEntry.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Xenial.Delicious.FeatureDetection.Win
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct WinProcessEntry : Toolhelp32.IEntry
+    {
+        [DllImport("kernel32.dll")]
+        internal static extern bool Process32Next(Toolhelp32.Snapshot snap, ref WinProcessEntry entry);
+
+        bool Toolhelp32.IEntry.TryMoveNext(Toolhelp32.Snapshot snap, out Toolhelp32.IEntry entry)
+        {
+            var x = new WinProcessEntry { dwSize = Marshal.SizeOf(typeof(WinProcessEntry)) };
+            var b = Process32Next(snap, ref x);
+            entry = x;
+            return b;
+        }
+
+        internal int dwSize;
+        internal int cntUsage;
+        internal int th32ProcessID;
+        internal IntPtr th32DefaultHeapID;
+        internal int th32ModuleID;
+        internal int cntThreads;
+        internal int th32ParentProcessID;
+        internal int pcPriClassBase;
+        internal int dwFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        internal string fileName;
+    }
+}

--- a/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.cs
+++ b/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace Xenial.Delicious.FeatureDetection.Win
+{
+    internal static class ProcessExtensions
+    {
+        internal static Process Parent(this Process p)
+        {
+            var entries = Toolhelp32.TakeSnapshot<WinProcessEntry>(Toolhelp32.SnapAll, 0);
+            var parentid = entries.First(x => x.th32ProcessID == p.Id).th32ParentProcessID;
+            return Process.GetProcessById(parentid);
+        }
+    }
+}

--- a/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.cs
+++ b/src/Xenial.Tasty/FeatureDetection/Win/ProcessExtensions.cs
@@ -1,8 +1,8 @@
-﻿using System.Diagnostics;
-using System.Runtime.InteropServices;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System;
+using System.Runtime.InteropServices;
 
 namespace Xenial.Delicious.FeatureDetection.Win
 {

--- a/src/Xenial.Tasty/Reporters/Reporters.ColorScheme.cs
+++ b/src/Xenial.Tasty/Reporters/Reporters.ColorScheme.cs
@@ -17,7 +17,7 @@ namespace Xenial.Delicious.Reporters
         public string NotRunIcon = "🙈";
         public string IgnoredIcon = "🙄";
 
-        public static ColorScheme Default = SupportsRichContent() 
+        public static ColorScheme Default = SupportsRichContent()
             ? new ColorScheme()
             : new ColorSchemeLegacy();
     }

--- a/src/Xenial.Tasty/Reporters/Reporters.ColorScheme.cs
+++ b/src/Xenial.Tasty/Reporters/Reporters.ColorScheme.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using static Xenial.Delicious.FeatureDetection.FeatureDetector;
+
 namespace Xenial.Delicious.Reporters
 {
     public class ColorScheme
@@ -15,6 +17,21 @@ namespace Xenial.Delicious.Reporters
         public string NotRunIcon = "🙈";
         public string IgnoredIcon = "🙄";
 
-        public static ColorScheme Default = new ColorScheme();
+        public static ColorScheme Default = SupportsRichContent() 
+            ? new ColorScheme()
+            : new ColorSchemeLegacy();
+    }
+
+    public class ColorSchemeLegacy : ColorScheme
+    {
+        public ColorSchemeLegacy()
+        {
+            SuccessIcon = "☺";
+            ErrorIcon = "▼";
+            NotRunIcon = "?";
+            IgnoredIcon = "‼";
+        }
+
+        public static new ColorScheme Default = new ColorSchemeLegacy();
     }
 }

--- a/src/Xenial.Tasty/Reporters/Reporters.Console.cs
+++ b/src/Xenial.Tasty/Reporters/Reporters.Console.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -17,8 +18,20 @@ namespace Xenial.Delicious.Reporters
         public static ColorScheme Scheme = ColorScheme.Default;
 
         static ConsoleReporter()
-            => Console.OutputEncoding = Encoding.UTF8;
+            => SetupConsoleEncoding();
 
+        private static void SetupConsoleEncoding()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                //Register additional code pages for windows
+                //cause we deal directly with process streams
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            }
+
+            Console.OutputEncoding = Encoding.UTF8;
+            Console.InputEncoding = Encoding.UTF8;
+        }
         public static void Register()
             => Tasty.RegisterReporter(Report)
                     .RegisterReporter(ReportSummary);

--- a/src/Xenial.Tasty/Xenial.Tasty.csproj
+++ b/src/Xenial.Tasty/Xenial.Tasty.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="StreamJsonRpc" Version="2.4.48" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xenial.Tasty/Xenial.Tasty.csproj
+++ b/src/Xenial.Tasty/Xenial.Tasty.csproj
@@ -11,5 +11,13 @@
   <ItemGroup>
     <PackageReference Include="StreamJsonRpc" Version="2.4.48" />
   </ItemGroup>
-    
+
+  <ItemGroup>
+    <None Include="THIRD-PARTY-NOTICES.TXT">
+      <Pack>true</Pack>
+      <PackagePath></PackagePath>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+  
 </Project>

--- a/test/Xenial.Tasty.Tests/Program.cs
+++ b/test/Xenial.Tasty.Tests/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+
 using static Xenial.Delicious.Tests.TastyScopeTests;
 using static Xenial.Delicious.Tests.TestExecutorTests;
 using static Xenial.Tasty;


### PR DESCRIPTION
- fixes #41 
- add the Terminal.Gui project as a submodule, as their docs state until they provide a stable nuget
- add the tasty cli studio to prep work for tasty snapshots
- add feature detection for cmd / powershell / old windows cmd without emoji support