### PR TITLE
fix(core): overload resolution for global scope

### DIFF
--- a/src/Xenial.Tasty/Tasty.cs
+++ b/src/Xenial.Tasty/Tasty.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Xenial.Delicious.Execution;
 using Xenial.Delicious.Metadata;
 using Xenial.Delicious.Remote;
 using Xenial.Delicious.Reporters;
@@ -135,7 +136,7 @@ namespace Xenial
         /// <param name="name">The name.</param>
         /// <param name="action">The action.</param>
         /// <returns>TestCase.</returns>
-        public static TestCase It(string name, Func<Task<bool>> action)
+        public static TestCase It(string name, Executable action)
             => TastyDefaultScope.It(name, action);
 
         /// <summary>

--- a/test/Xenial.Tasty.Tests/TestExecutorTests.Overloads.cs
+++ b/test/Xenial.Tasty.Tests/TestExecutorTests.Overloads.cs
@@ -77,6 +77,38 @@ namespace Xenial.Delicious.Tests
                     await scope.Run();
                     A.CallTo(action).MustHaveHappenedOnceExactly();
                 });
+
+                It("It should allow Func<Task<false>>", async () =>
+                {
+                    var (scope, _) = CreateScope<Func<Task<bool>>>();
+
+                    var testCase = scope.It(TestName, async () =>
+                    {
+                        await Task.CompletedTask;
+
+                        return false;
+                    });
+
+                    await scope.Run();
+
+                    return testCase.TestOutcome == Metadata.TestOutcome.Failed;
+                });
+
+                It("It should allow Func<Task<true>>", async () =>
+                {
+                    var (scope, _) = CreateScope<Func<Task<bool>>>();
+
+                    var testCase = scope.It(TestName, async () =>
+                    {
+                        await Task.CompletedTask;
+
+                        return true;
+                    });
+
+                    await scope.Run();
+                    Console.WriteLine(testCase.TestOutcome);
+                    return testCase.TestOutcome == Metadata.TestOutcome.Success;
+                });
             });
         }
     }


### PR DESCRIPTION
cause c# chooses the wrong overload by default we use executable now

fix #55